### PR TITLE
Adding stencil to the Frame Buffer:  DxGLFrameBuffer.cs

### DIFF
--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -97,11 +97,17 @@ namespace OpenTK.Wpf {
 
             GLDepthRenderBufferHandle = GL.GenRenderbuffer();
             GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, GLDepthRenderBufferHandle);
-            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferStorage.DepthComponent24, FramebufferWidth, FramebufferHeight);
+            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, RenderbufferStorage.Depth24Stencil8, FramebufferWidth, FramebufferHeight);
+            
             GL.FramebufferRenderbuffer(
                 FramebufferTarget.Framebuffer,
                 FramebufferAttachment.DepthAttachment,
                 RenderbufferTarget.Renderbuffer,
+                GLDepthRenderBufferHandle);
+            GL.FramebufferRenderbuffer(
+                FramebufferTarget.Framebuffer,
+                FramebufferAttachment.StencilAttachment,
+                RenderbufferTarget.Renderbuffer, 
                 GLDepthRenderBufferHandle);
 
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);


### PR DESCRIPTION
This small modification of the frame buffer allows the stencil tests to be used. That is, in certain cases, extremely fast and useful feature. It allows for example to render an area of nonconvex polygons (even with holes inside) knowing just their boundary. And much more.
This simple change has been originally suggested by Varon. I have made that change and tested on my code - works well.