### PR TITLE
Add ability to pass custom IBindingsContext to GLWpfControlSettings

### DIFF
--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -107,7 +107,7 @@ namespace OpenTK.Wpf {
                 nws.WindowBorder = WindowBorder.Hidden;
                 nws.WindowState = WindowState.Minimized;
                 var glfwWindow = new NativeWindow(nws);
-                var provider = new GLFWBindingsContext();
+                var provider = settings.BindingsContext ?? new GLFWBindingsContext();
                 Wgl.LoadBindings(provider);
                 // we're already in a window context, so we can just cheat by creating a new dependency object here rather than passing any around.
                 var depObject = new DependencyObject();

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -17,6 +17,9 @@ namespace OpenTK.Wpf {
         /// for managing the lifetime and disposal of.
         public IGraphicsContext ContextToUse { get; set; }
 
+        /// May ne null. If so, default bindings context will be used.
+        public IBindingsContext BindingsContext { get; set; }
+
         public ContextFlags GraphicsContextFlags { get; set; } = ContextFlags.Default;
         public ContextProfile GraphicsProfile { get; set; } = ContextProfile.Any;
 
@@ -30,6 +33,7 @@ namespace OpenTK.Wpf {
         internal GLWpfControlSettings Copy() {
             var c = new GLWpfControlSettings {
                 ContextToUse = ContextToUse,
+                BindingsContext = BindingsContext,
                 GraphicsContextFlags = GraphicsContextFlags,
                 GraphicsProfile = GraphicsProfile,
                 MajorVersion = MajorVersion,

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -17,7 +17,7 @@ namespace OpenTK.Wpf {
         /// for managing the lifetime and disposal of.
         public IGraphicsContext ContextToUse { get; set; }
 
-        /// May ne null. If so, default bindings context will be used.
+        /// May be null. If so, default bindings context will be used.
         public IBindingsContext BindingsContext { get; set; }
 
         public ContextFlags GraphicsContextFlags { get; set; } = ContextFlags.Default;


### PR DESCRIPTION
Sometimes it is needed to call or pass callback to `wglGetProcAddress` for some third-party OpenGL libraries.
This allows to create `GLFWBindingsContext` manually and pass it to `GLWpfControl` and then also use it as `wglGetProcAdress` for such third-party OpenGL libraries.