### PR TITLE
displace async method GL.Flush() to GL.Finish() 

### DIFF
--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -59,7 +59,7 @@ namespace OpenTK.Wpf
             PreRender();
             GLRender?.Invoke(deltaT);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-            GL.Flush();
+            GL.Finish();
             GLAsyncRender?.Invoke();
             PostRender();
             


### PR DESCRIPTION
displace async method GL.Flush() to GL.Finish() as it will cause flicker when high pressure of render. Besides, I think there's no need to switch between async and sync .