### PR TITLE
Configure the control to allow transparency

### DIFF
--- a/src/Example/ExampleScene.cs
+++ b/src/Example/ExampleScene.cs
@@ -16,9 +16,9 @@ namespace Example {
             GL.Enable(EnableCap.ScissorTest);
         }
 
-        public static void Render() {
+        public static void Render(float alpha = 1.0f) {
             var hue = (float) _stopwatch.Elapsed.TotalSeconds * 0.15f % 1;
-            var c = Color4.FromHsv(new Vector4(hue, 0.75f, 0.75f, 1));
+            var c = Color4.FromHsv(new Vector4(alpha * hue, alpha * 0.75f, alpha * 0.75f, alpha));
             GL.ClearColor(c);
             GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
             GL.LoadIdentity();

--- a/src/Example/TabbedMainWindowTest.xaml
+++ b/src/Example/TabbedMainWindowTest.xaml
@@ -23,8 +23,20 @@
 				x:Name="Control2"
 				Render="Control2_OnRender" />
 		</TabItem>
-		<TabItem Header="Blank 3">
-		</TabItem>
+		<TabItem Header="Control 3">
+            <Grid>
+                <Label
+                Background="#FFE6931C"
+                Content="BEHIND       CONTROL"
+                FontSize="50px"
+                HorizontalContentAlignment="Center"
+                Padding="45px 180px 0px 0px" />
+
+                <glWpfControl:GLWpfControl
+				    x:Name="Control3"
+				    Render="Control3_OnRender" />
+            </Grid>
+        </TabItem>
 		<TabItem Header="Blank 4">
 		</TabItem>
 	</glWpfControl:NonReloadingTabControl>

--- a/src/Example/TabbedMainWindowTest.xaml.cs
+++ b/src/Example/TabbedMainWindowTest.xaml.cs
@@ -15,6 +15,8 @@ namespace Example {
             Control1.Start(mainSettings);
             var insetSettings = new GLWpfControlSettings {MajorVersion = 4, MinorVersion = 5, GraphicsProfile = ContextProfile.Compatability, GraphicsContextFlags = ContextFlags.Debug};
             Control2.Start(insetSettings);
+            var transparentSettings = new GLWpfControlSettings { MajorVersion = 4, MinorVersion = 5, GraphicsProfile = ContextProfile.Compatability, GraphicsContextFlags = ContextFlags.Debug, TransparentBackground = true};
+            Control3.Start(transparentSettings);
         }
 
         private void OpenTkControl_OnRender(TimeSpan delta) {
@@ -27,6 +29,11 @@ namespace Example {
 
         private void Control1_OnRender(TimeSpan delta) {
 	        ExampleScene.Render();
+        }
+
+        private void Control3_OnRender(TimeSpan delta)
+        {
+            ExampleScene.Render(0.0f);
         }
     }
 }

--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -65,7 +65,7 @@ namespace OpenTK.Wpf {
                 context.DxDeviceHandle,
                 FramebufferWidth,
                 FramebufferHeight,
-                format,// this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice.
+                format,
                 MultisampleType.None,
                 0,
                 false,

--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -53,7 +53,7 @@ namespace OpenTK.Wpf {
         public ScaleTransform FlipYTransform { get; }
 
 
-        public DxGLFramebuffer([NotNull] DxGlContext context, int width, int height, double dpiScaleX, double dpiScaleY) {
+        public DxGLFramebuffer([NotNull] DxGlContext context, int width, int height, double dpiScaleX, double dpiScaleY, Format format) {
             DxGlContext = context;
             Width = width;
             Height = height;
@@ -65,7 +65,7 @@ namespace OpenTK.Wpf {
                 context.DxDeviceHandle,
                 FramebufferWidth,
                 FramebufferHeight,
-                Format.X8R8G8B8,// this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice.
+                format,// this is like A8 R8 G8 B8, but avoids issues with Gamma correction being applied twice.
                 MultisampleType.None,
                 0,
                 false,

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using JetBrains.Annotations;
+using OpenTK.Wpf.Interop;
 
 namespace OpenTK.Wpf
 {
@@ -125,12 +126,13 @@ namespace OpenTK.Wpf
                     dpiScaleY = transformToDevice.M22;
                 }
             }
-            _renderer?.SetSize((int) RenderSize.Width, (int) RenderSize.Height, dpiScaleX, dpiScaleY);
+            var format = _settings.TransparentBackground ? Format.A8R8G8B8 : Format.X8R8G8B8;
+            _renderer?.SetSize((int) RenderSize.Width, (int) RenderSize.Height, dpiScaleX, dpiScaleY, format);
         }
 
         private void OnUnloaded()
         {
-            _renderer?.SetSize(0,0, 1, 1);
+            _renderer?.SetSize(0,0, 1, 1, Format.X8R8G8B8);
         }
 
         private void OnCompTargetRender(object sender, EventArgs e)

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -39,12 +39,12 @@ namespace OpenTK.Wpf
         }
 
 
-        public void SetSize(int width, int height, double dpiScaleX, double dpiScaleY) {
+        public void SetSize(int width, int height, double dpiScaleX, double dpiScaleY, Format format) {
             if (_framebuffer == null || _framebuffer.Width != width || _framebuffer.Height != height) {
                 _framebuffer?.Dispose();
                 _framebuffer = null;
                 if (width > 0 && height > 0) {
-                    _framebuffer = new DxGLFramebuffer(_context, width, height, dpiScaleX, dpiScaleY);
+                    _framebuffer = new DxGLFramebuffer(_context, width, height, dpiScaleX, dpiScaleY, format);
                 }
             }
         }

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -13,6 +13,10 @@ namespace OpenTK.Wpf {
         /// This setting may be useful to get extra performance on mobile platforms.
         public bool UseDeviceDpi { get; set; } = true;
 
+        // If this parameter is set to true, the alpha channel of the color passed to the function GL.ClearColor
+        // will determine the level of transparency of this control
+        public bool TransparentBackground { get; set; } = false;
+
         /// May be null. If defined, an external context will be used, of which the caller is responsible
         /// for managing the lifetime and disposal of.
         public IGraphicsContext ContextToUse { get; set; }
@@ -39,7 +43,8 @@ namespace OpenTK.Wpf {
                 MajorVersion = MajorVersion,
                 MinorVersion = MinorVersion,
                 RenderContinuously = RenderContinuously,
-                UseDeviceDpi = UseDeviceDpi
+                UseDeviceDpi = UseDeviceDpi,
+                TransparentBackground = TransparentBackground
             };
             return c;
         }

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -13,8 +13,8 @@ namespace OpenTK.Wpf {
         /// This setting may be useful to get extra performance on mobile platforms.
         public bool UseDeviceDpi { get; set; } = true;
 
-        // If this parameter is set to true, the alpha channel of the color passed to the function GL.ClearColor
-        // will determine the level of transparency of this control
+        /// If this parameter is set to true, the alpha channel of the color passed to the function GL.ClearColor
+        /// will determine the level of transparency of this control
         public bool TransparentBackground { get; set; } = false;
 
         /// May be null. If defined, an external context will be used, of which the caller is responsible


### PR DESCRIPTION
Issue [59](https://github.com/opentk/GLWpfControl/issues/59)

Changing the frame buffer format to `A8R8G8B8`, the alpha channel of the color passed to the function GL.ClearColor will determine now the level of transparency of the control.