### PR TITLE
Remove unecessary call to GL.FLush

### DIFF
--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -56,13 +56,23 @@ namespace OpenTK.Wpf
             var curFrameStamp = _stopwatch.Elapsed;
             var deltaT = curFrameStamp - _lastFrameStamp;
             _lastFrameStamp = curFrameStamp;
-            PreRender();
+
+            // Lock the interop object, DX calls to the framebuffer are no longer valid
+            _framebuffer.D3dImage.Lock();
+            Wgl.DXLockObjectsNV(_context.GlDeviceHandle, 1, new[] { _framebuffer.DxInteropRegisteredHandle });
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, _framebuffer.GLFramebufferHandle);
+            GL.Viewport(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight);
+
             GLRender?.Invoke(deltaT);
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-            GL.Flush();
             GLAsyncRender?.Invoke();
-            PostRender();
-            
+
+            // Unlock the interop object, this acts as a synchronization point. OpenGL draws to the framebuffer are no longer valid.
+            Wgl.DXUnlockObjectsNV(_context.GlDeviceHandle, 1, new[] { _framebuffer.DxInteropRegisteredHandle });
+            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle, true);
+            _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight));
+            _framebuffer.D3dImage.Unlock();
+
             // Transforms are applied in reverse order
             drawingContext.PushTransform(_framebuffer.TranslateTransform);              // Apply translation to the image on the Y axis by the height. This assures that in the next step, where we apply a negative scale the image is still inside of the window
             drawingContext.PushTransform(_framebuffer.FlipYTransform);                  // Apply a scale where the Y axis is -1. This will rotate the image by 180 deg
@@ -73,24 +83,6 @@ namespace OpenTK.Wpf
 
             drawingContext.Pop();                                                       // Remove the scale transform
             drawingContext.Pop();                                                       // Remove the translation transform
-        }
-
-        /// Sets up the framebuffer, directx stuff for rendering. 
-        private void PreRender()
-        {
-            _framebuffer.D3dImage.Lock();
-            Wgl.DXLockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
-            GL.BindFramebuffer(FramebufferTarget.Framebuffer, _framebuffer.GLFramebufferHandle);
-            GL.Viewport(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight);
-        }
-
-        /// Sets up the framebuffer and prepares stuff for usage in directx.
-        private void PostRender()
-        {
-            Wgl.DXUnlockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
-            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle, true);
-            _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight));
-            _framebuffer.D3dImage.Unlock();
         }
     }
 }


### PR DESCRIPTION
The `WGL_DX_NV_interop` extension should handle the synchronization between GL and DX.

Closes #51