### PR TITLE
Fix Events Issue

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -74,6 +74,10 @@ namespace OpenTK.Wpf
         public int FrameBufferHeight => _renderer?.Height ?? 0;
 
         private TimeSpan _lastRenderTime = TimeSpan.FromSeconds(-1);
+		
+		public bool CanInvokeOnHandledEvents { get; set; } = true;
+		
+		public bool RegisterToEventsDirectly { get; set; } = true;
 
         /// <summary>
         /// Used to create a new control. Before rendering can take place, <see cref="Start(GLWpfControlSettings)"/> must be called.
@@ -103,9 +107,12 @@ namespace OpenTK.Wpf
             };
 
             // Inheriting directly from a FrameworkElement has issues with receiving certain events -- register for these events directly
-            EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyDownEvent, new KeyEventHandler(OnKeyDown), true);
-            EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyUpEvent, new KeyEventHandler(OnKeyUp), true);
-
+            if (RegisterToEventsDirectly)
+			{
+				EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyDownEvent, new KeyEventHandler(OnKeyDown), CanInvokeOnHandledEvents);
+				EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyUpEvent, new KeyEventHandler(OnKeyUp), CanInvokeOnHandledEvents);
+			}
+			
             Loaded += (a, b) => {
                 InvalidateVisual();
             };

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -108,10 +108,10 @@ namespace OpenTK.Wpf
 
             // Inheriting directly from a FrameworkElement has issues with receiving certain events -- register for these events directly
             if (RegisterToEventsDirectly)
-			{
-				EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyDownEvent, new KeyEventHandler(OnKeyDown), CanInvokeOnHandledEvents);
-				EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyUpEvent, new KeyEventHandler(OnKeyUp), CanInvokeOnHandledEvents);
-			}
+	    {
+	        EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyDownEvent, new KeyEventHandler(OnKeyDown), CanInvokeOnHandledEvents);
+		EventManager.RegisterClassHandler(typeof(Control), Keyboard.KeyUpEvent, new KeyEventHandler(OnKeyUp), CanInvokeOnHandledEvents);
+	    }
 			
             Loaded += (a, b) => {
                 InvalidateVisual();


### PR DESCRIPTION
Simply just added two new properties to help users determine whether they'd like to hook onto events directly with the EventManager or instead handle input themselves. This makes the control more versatile and also acts a workaround to the issue where controls events are being invoked twice; once for the event manager and once for the control.