### PR TITLE
fix remote desktop issue in 3.x

### DIFF
--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -87,7 +87,7 @@ namespace OpenTK.Wpf
         private void PostRender()
         {
             Wgl.DXUnlockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
-            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle);
+            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle, true);
             _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight));
             _framebuffer.D3dImage.Unlock();
         }


### PR DESCRIPTION
This adds the same fix to enable software fallback to the 3.x version that was introduced to master recently.