### PR TITLE
Added compatibility Window Remote Desktop in 3.x

### DIFF
--- a/src/Example/TabbedMainWindowTest.xaml
+++ b/src/Example/TabbedMainWindowTest.xaml
@@ -23,8 +23,11 @@
 				x:Name="Control2"
 				Render="Control2_OnRender" />
 		</TabItem>
-		<TabItem Header="Blank 3">
-		</TabItem>
+        <TabItem Header="Control 3">
+            <glWpfControl:GLWpfControl
+				x:Name="Control3"
+				Render="Control3_OnRender" />
+        </TabItem>
 		<TabItem Header="Blank 4">
 		</TabItem>
 	</glWpfControl:NonReloadingTabControl>

--- a/src/Example/TabbedMainWindowTest.xaml.cs
+++ b/src/Example/TabbedMainWindowTest.xaml.cs
@@ -14,6 +14,8 @@ namespace Example {
             Control1.Start(mainSettings);
             var insetSettings = new GLWpfControlSettings {MajorVersion = 2, MinorVersion = 1};
             Control2.Start(insetSettings);
+            var remoteAppSettings = new GLWpfControlSettings { MajorVersion = 2, MinorVersion = 1 , EnableSoftwareFallback= true };
+            Control3.Start(remoteAppSettings);
         }
 
         private void OpenTkControl_OnRender(TimeSpan delta) {
@@ -26,6 +28,11 @@ namespace Example {
 
         private void Control1_OnRender(TimeSpan delta) {
 	        ExampleScene.Render();
+        }
+
+        private void Control3_OnRender(TimeSpan obj)
+        {
+            ExampleScene.Render();
         }
     }
 }

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -31,10 +31,12 @@ namespace OpenTK.Wpf
         
         private TimeSpan _lastFrameStamp;
 
+        private bool _enableSoftwareFallback;
 
         public GLWpfControlRenderer(GLWpfControlSettings settings)
         {
             _context = new DxGlContext(settings);
+            _enableSoftwareFallback = settings.EnableSoftwareFallback;
         }
 
 
@@ -87,7 +89,7 @@ namespace OpenTK.Wpf
         private void PostRender()
         {
             Wgl.DXUnlockObjectsNV(_context.GlDeviceHandle, 1, new [] {_framebuffer.DxInteropRegisteredHandle});
-            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle);
+            _framebuffer.D3dImage.SetBackBuffer(D3DResourceType.IDirect3DSurface9, _framebuffer.DxRenderTargetHandle, _enableSoftwareFallback);
             _framebuffer.D3dImage.AddDirtyRect(new Int32Rect(0, 0, _framebuffer.FramebufferWidth, _framebuffer.FramebufferHeight));
             _framebuffer.D3dImage.Unlock();
         }

--- a/src/GLWpfControl/GLWpfControlSettings.cs
+++ b/src/GLWpfControl/GLWpfControlSettings.cs
@@ -26,7 +26,8 @@ namespace OpenTK.Wpf {
 
         /// If we are using an external context for the control.
         public bool IsUsingExternalContext => ContextToUse != null;
-        
+        public bool EnableSoftwareFallback { get; set; }
+
         /// Creates a copy of the settings.
         internal GLWpfControlSettings Copy() {
             var c = new GLWpfControlSettings {
@@ -36,7 +37,8 @@ namespace OpenTK.Wpf {
                 MajorVersion = MajorVersion,
                 MinorVersion = MinorVersion,
                 RenderContinuously = RenderContinuously,
-                UseDeviceDpi = UseDeviceDpi
+                UseDeviceDpi = UseDeviceDpi,
+                EnableSoftwareFallback = EnableSoftwareFallback
             };
             return c;
         }


### PR DESCRIPTION
It is not shown in Windows Remote Desktop.
I only see a gray screen.
So, looking for a solution, I found the following solution:
https://github.com/opentk/GLWpfControl/issues/42
By the way, we still use the .Net Framework.
So, I would appreciate it if you could add and release it.

1. add example use.
2.It has been modified to be able to determine whether to use it externally through GLWpfControlSettings.