### PR TITLE
Avoid rounding errors in size calculation.

### DIFF
--- a/src/GLWpfControl/DxGLFramebuffer.cs
+++ b/src/GLWpfControl/DxGLFramebuffer.cs
@@ -26,10 +26,10 @@ namespace OpenTK.Wpf {
         public int FramebufferHeight { get; }
 
         /// The width of the element in device-independent pixels
-        public int Width { get; }
+        public double Width { get; }
 
         /// The height of the element in device-independent pixels
-        public int Height { get; }
+        public double Height { get; }
         
         /// The DirectX Render target (framebuffer) handle.
         public IntPtr DxRenderTargetHandle { get; }
@@ -53,7 +53,7 @@ namespace OpenTK.Wpf {
         public ScaleTransform FlipYTransform { get; }
 
 
-        public DxGLFramebuffer([NotNull] DxGlContext context, int width, int height, double dpiScaleX, double dpiScaleY, Format format) {
+        public DxGLFramebuffer([NotNull] DxGlContext context, double width, double height, double dpiScaleX, double dpiScaleY, Format format) {
             DxGlContext = context;
             Width = width;
             Height = height;

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -133,7 +133,7 @@ namespace OpenTK.Wpf
                 }
             }
             var format = _settings.TransparentBackground ? Format.A8R8G8B8 : Format.X8R8G8B8;
-            _renderer?.SetSize((int) RenderSize.Width, (int) RenderSize.Height, dpiScaleX, dpiScaleY, format);
+            _renderer?.SetSize(RenderSize.Width, RenderSize.Height, dpiScaleX, dpiScaleY, format);
         }
 
         private void OnUnloaded()

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -39,7 +39,7 @@ namespace OpenTK.Wpf
         }
 
 
-        public void SetSize(int width, int height, double dpiScaleX, double dpiScaleY, Format format) {
+        public void SetSize(double width, double height, double dpiScaleX, double dpiScaleY, Format format) {
             if (_framebuffer == null || _framebuffer.Width != width || _framebuffer.Height != height) {
                 _framebuffer?.Dispose();
                 _framebuffer = null;


### PR DESCRIPTION
Width and height are normally fractional when DPI scaling is enabled, converting them to int will introduce rounding errors, and sometimes produces white lines on the right and bottom of the control.
To avoid this, they are now stored as double, the same as in UIElement.RenderSize.