### PR TITLE
removing _needsRedraw

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -44,7 +44,6 @@ namespace OpenTK.Wpf
         
         [CanBeNull] private GLWpfControlSettings _settings;
         [CanBeNull] private GLWpfControlRenderer _renderer;
-        private bool _needsRedraw;
 
         // -----------------------------------
         // Properties
@@ -89,7 +88,6 @@ namespace OpenTK.Wpf
                 throw new InvalidOperationException($"{nameof(Start)} must only be called once for a given {nameof(GLWpfControl)}");
             }
             _settings = settings.Copy();
-            _needsRedraw = settings.RenderContinuously;
             _renderer = new GLWpfControlRenderer(_settings);
             _renderer.GLRender += timeDelta => Render?.Invoke(timeDelta);
             _renderer.GLAsyncRender += () => AsyncRender?.Invoke();
@@ -176,11 +174,7 @@ namespace OpenTK.Wpf
 
             _lastRenderTime = currentRenderTime.Value;
 
-            if (_needsRedraw) {
-                InvalidateVisual();
-            }
-
-            _needsRedraw = RenderContinuously;
+            if (RenderContinuously) InvalidateVisual();
         }
 
         protected override void OnRender(DrawingContext drawingContext) {

--- a/src/GLWpfControl/GLWpfControl.csproj
+++ b/src/GLWpfControl/GLWpfControl.csproj
@@ -8,10 +8,10 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-      <PackageReference Include="OpenTK" Version="4.7.1" />
+      <PackageReference Include="OpenTK" Version="4.7.5" />
     </ItemGroup>
 
-    <PropertyGroup >
+    <PropertyGroup>
       <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
1) It is redundant
2) If setting RenderContinuously to false in the render handler, an undesired additional last call to the render handler (due to invalidation in OnCompTarget) ; this change fixes this.