### PR TITLE
Added support to modify the GLWpfControlSettings within XAML front-end.

### DIFF
--- a/src/Example/MainWindow.xaml
+++ b/src/Example/MainWindow.xaml
@@ -15,8 +15,8 @@
             Render="OpenTkControl_OnRender">
             
             <glWpfControl:GLWpfControl.Settings>
-                <glWpfControl:GLWpfControlSettings MinorVersion="2"
-                                                   MajorVersion="1"/>
+                <glWpfControl:GLWpfControlSettings MajorVersion="2"
+                                                   MinorVersion="1"/>
             </glWpfControl:GLWpfControl.Settings>
             
         </glWpfControl:GLWpfControl>

--- a/src/Example/MainWindow.xaml
+++ b/src/Example/MainWindow.xaml
@@ -12,7 +12,14 @@
     <Grid>
         <glWpfControl:GLWpfControl
             x:Name="OpenTkControl"
-            Render="OpenTkControl_OnRender" />
+            Render="OpenTkControl_OnRender">
+            
+            <glWpfControl:GLWpfControl.Settings>
+                <glWpfControl:GLWpfControlSettings MinorVersion="2"
+                                                   MajorVersion="1"/>
+            </glWpfControl:GLWpfControl.Settings>
+            
+        </glWpfControl:GLWpfControl>
         <Border
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
@@ -32,7 +39,7 @@
             Height="128"
             HorizontalAlignment="Left"
             VerticalAlignment="Bottom"
-            Margin="10,0,0,60" />
+            Margin="10,0,0,60"/>
         <Button
             Content="Redraw Inset Control"
             HorizontalAlignment="Left"

--- a/src/Example/MainWindow.xaml.cs
+++ b/src/Example/MainWindow.xaml.cs
@@ -9,10 +9,17 @@ namespace Example {
     public sealed partial class MainWindow {
         public MainWindow() {
             InitializeComponent();
-            var mainSettings = new GLWpfControlSettings {MajorVersion = 2, MinorVersion = 1};
-            OpenTkControl.Start(mainSettings);
-            var insetSettings = new GLWpfControlSettings {MajorVersion = 2, MinorVersion = 1, RenderContinuously = false};
-            InsetControl.Start(insetSettings);
+
+            // You can start and rely on the Settings property that may be set in XAML or elsewhere in the codebase.
+            OpenTkControl.Start();
+
+            // Or, you can suppy a settings object directly.
+            InsetControl.Start(new GLWpfControlSettings()
+            {
+                MajorVersion = 2,
+                MinorVersion = 1,
+                RenderContinuously = false,
+            });
         }
 
         private void OpenTkControl_OnRender(TimeSpan delta) {

--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -88,8 +88,8 @@ namespace OpenTK.Wpf {
                 var isSameContext = GLWpfControlSettings.WouldResultInSameContext(settings, _sharedContextSettings);
                 if (!isSameContext) {
                     throw new ArgumentException($"The provided {nameof(GLWpfControlSettings)} would result" +
-                                                $"in a different context creation to one previously created. To fix this," +
-                                                $" either ensure all of your context settings are identical, or provide an " +
+                                                $"in a different context creation to one previously created. To fix this, " +
+                                                $"either ensure all of your context settings are identical, or provide an " +
                                                 $"external context via the '{nameof(GLWpfControlSettings.ContextToUse)}' field.");
                 }
             } 

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -20,12 +20,6 @@ namespace OpenTK.Wpf
     /// </summary>
     public class GLWpfControl : FrameworkElement
     {
-        /// <summary>
-        /// Represents the dependency property for <see cref="Settings"/>.
-        /// </summary>
-        public static readonly DependencyProperty SettingsProperty = DependencyProperty.Register(
-            "Settings", typeof(GLWpfControlSettings), typeof(GLWpfControl));
-
         // -----------------------------------
         // EVENTS
         // -----------------------------------
@@ -47,13 +41,23 @@ namespace OpenTK.Wpf
         // -----------------------------------
         // Fields
         // -----------------------------------
-        
+
+        /// <summary>
+        /// Represents the dependency property for <see cref="Settings"/>.
+        /// </summary>
+        public static readonly DependencyProperty SettingsProperty = DependencyProperty.Register(
+            "Settings", typeof(GLWpfControlSettings), typeof(GLWpfControl));
+
         [CanBeNull] private GLWpfControlRenderer _renderer;
 
         /// <summary>
         /// Indicates whether the <see cref="Start"/> function has been invoked.
         /// </summary>
         private bool _isStarted;
+
+        // -----------------------------------
+        // Properties
+        // -----------------------------------
 
         /// <summary>
         /// Gets or sets the settings used when initializing the control.
@@ -66,10 +70,6 @@ namespace OpenTK.Wpf
             get { return (GLWpfControlSettings)GetValue(SettingsProperty); }
             set { SetValue(SettingsProperty, value); }
         }
-
-        // -----------------------------------
-        // Properties
-        // -----------------------------------
 
         /// The OpenGL Framebuffer Object used internally by this component.
         /// Bind to this instead of the default framebuffer when using this component along with other FrameBuffers for the final pass.

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -20,6 +20,9 @@ namespace OpenTK.Wpf
     /// </summary>
     public class GLWpfControl : FrameworkElement
     {
+        /// <summary>
+        /// Represents the dependency property for <see cref="Settings"/>.
+        /// </summary>
         public static readonly DependencyProperty SettingsProperty = DependencyProperty.Register(
             "Settings", typeof(GLWpfControlSettings), typeof(GLWpfControl));
 
@@ -129,6 +132,8 @@ namespace OpenTK.Wpf
                 throw new InvalidOperationException($"{nameof(Start)} must only be called once for a given {nameof(GLWpfControl)}");
             }
 
+            _isStarted = true;
+
             Settings = settings.Copy();
             _renderer = new GLWpfControlRenderer(Settings);
             _renderer.GLRender += timeDelta => Render?.Invoke(timeDelta);
@@ -154,8 +159,6 @@ namespace OpenTK.Wpf
             };
             Unloaded += (a, b) => OnUnloaded();
             Ready?.Invoke();
-
-            _isStarted = true;
         }
         
         private void SetupRenderSize() {


### PR DESCRIPTION
# Description

- Added a `Start` function overload that does not take any arguments; it relies on the `Settings` attached property.
  - This required the addition of a new field to check whether the control has been started.
- Modified the example project to showcase both use cases.

Fixes #105

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I tested this locally on my machine and ensured that everything was still functioning as normal within the example project.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-10710U @ 1.1GHz, 32GB RAM
* Toolchain: VS Community 2022

## Proposed Design

```xaml
<glWpfControl:GLWpfControl
	x:Name="OpenTkControl"
	Render="OpenTkControl_OnRender">
	
        <!-- Add settings object -->
	<glWpfControl:GLWpfControl.Settings>
		<glWpfControl:GLWpfControlSettings MinorVersion="2" MajorVersion="1"/>
	</glWpfControl:GLWpfControl.Settings>
	
</glWpfControl:GLWpfControl>
```

```csharp
// Now, we can just call start within the code behind.
this.OpenTKControl.Start();

// Or, provide settings as we did before.
OpenTKControl.Start(new GLWpfControlSettings()
{
	MajorVersion = 2,
	MinorVersion = 1,
	RenderContinuously = false,
});
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
