### PR TITLE
Updated `PackageReference` from 4.7.5 to 4.8.0.

### DIFF
--- a/src/Example/Example.csproj
+++ b/src/Example/Example.csproj
@@ -13,6 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="OpenTK" Version="4.7.5" />
+      <PackageReference Include="OpenTK" Version="4.8.0" />
     </ItemGroup>
 </Project>

--- a/src/GLWpfControl/GLWpfControl.csproj
+++ b/src/GLWpfControl/GLWpfControl.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-      <PackageReference Include="OpenTK" Version="4.7.5" />
+      <PackageReference Include="OpenTK" Version="4.8.0" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
# Description

- Updated `PackageReference` for `GLWpfControl.csproj`.
- Updated `PackageReference` for `Example.csproj`.

Fixes #114 

## Dependencies

- [OpenTK 4.8.0](https://www.nuget.org/packages/OpenTK/).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

I tested the example locally on my machine and everything still needs to be working. Furthermore, I created my own local package and tested it in my own personal project to make sure that I would no longer receive the warnings described in #114.

![image](https://github.com/opentk/GLWpfControl/assets/50978201/aedee1fd-6728-4813-8c62-40063571e762)

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 32GB RAM, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Possible Issues

I don't know if this will directly fix the issue once a new release is made. I think there is something that the maintainers of the NuGet package will have to address unless I can be pointed in the right direction. When uploading my own package of the control to NuGet instead of checking if the version was between 4.3.0 and 5.0.0 it ensured that it was greater than or equal to 4.8.0.

![image](https://github.com/opentk/GLWpfControl/assets/50978201/16d211af-e3d5-4d99-8940-077d01ebb340)