### PR TITLE
Fix OpenGL context issues when using multiple GLWpfControls.

### DIFF
--- a/src/Example/TabbedMainWindowTest.xaml.cs
+++ b/src/Example/TabbedMainWindowTest.xaml.cs
@@ -22,14 +22,17 @@ namespace Example
             InitializeComponent();
             GLWpfControlSettings mainSettings = new GLWpfControlSettings {MajorVersion = 4, MinorVersion = 1, Profile = ContextProfile.Compatability, ContextFlags = ContextFlags.Debug};
             Control1.Start(mainSettings);
+            Control1.Context.MakeCurrent();
             scene1.Initialize();
 
             GLWpfControlSettings insetSettings = new GLWpfControlSettings {MajorVersion = 4, MinorVersion = 1, Profile = ContextProfile.Compatability, ContextFlags = ContextFlags.Debug, Samples = 8};
             Control2.Start(insetSettings);
+            Control2.Context.MakeCurrent();
             scene2.Initialize();
 
             GLWpfControlSettings transparentSettings = new GLWpfControlSettings { MajorVersion = 4, MinorVersion = 1, Profile = ContextProfile.Compatability, ContextFlags = ContextFlags.Debug, TransparentBackground = true};
             Control3.Start(transparentSettings);
+            Control3.Context.MakeCurrent();
             scene3.Initialize();
 
             Control1.KeyDown += Control1_KeyDown;

--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -29,6 +29,7 @@ namespace OpenTK.Wpf
 
         /// <summary>
         /// Called whenever rendering should occur.
+        /// GLWpfControl makes sure that it's OpenGL context is current when this event happens.
         /// </summary>
         public event Action<TimeSpan>? Render;
 
@@ -37,7 +38,10 @@ namespace OpenTK.Wpf
         /// This is only for extremely advanced use, where a non-display out task needs to run.
         /// Examples of these are an async Pixel Buffer Object transfer or Transform Feedback.
         /// If you do not know what these are, do not use this function.
+        /// 
+        /// GLWpfControl makes sure that it's OpenGL context is current when this event happens.
         /// </summary>
+        [Obsolete("There is no difference between Render and AsyncRender. Use Render.")]
         public event Action? AsyncRender;
 
         /// <summary>

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -22,6 +22,7 @@ namespace OpenTK.Wpf
         private readonly DxGlContext _context;
 
         public event Action<TimeSpan>? GLRender;
+        [Obsolete("There is no difference between GLRender and GLAsyncRender. Use GLRender.")]
         public event Action? GLAsyncRender;
 
         /// <summary>The width of this buffer in pixels.</summary>
@@ -76,6 +77,8 @@ namespace OpenTK.Wpf
 
             if (D3dImage == null || FramebufferWidth != newWidth || FramebufferHeight != newHeight || MultisampleType != msaaType)
             {
+                _context.GraphicsContext.MakeCurrent();
+
                 if (D3dImage != null)
                 {
                     GL.DeleteFramebuffer(GLFramebufferHandle);
@@ -194,6 +197,8 @@ namespace OpenTK.Wpf
             {
                 return;
             }
+
+            _context.GraphicsContext.MakeCurrent();
 
             TimeSpan curFrameStamp = _stopwatch.Elapsed;
             TimeSpan deltaT = curFrameStamp - _lastFrameStamp;


### PR DESCRIPTION
With `4.3.0` every GLWpfControl has it's own OpenGL context.
The example project kept working as all of the different contexts where using the same numbers, but everything was actually just rendered using the last created context.

This PR fixes this to make GLWpfControlRenderer call `Context.MakeCurrent()` before doing any OpenGL operations.
We should document that the GLWpfControl uses is not safe to make current on any other thread as GLWpfControl might need to make the context current basically at any time.