### PR TITLE
Try to fix integrated graphics

### DIFF
--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -68,14 +68,15 @@ namespace OpenTK.Wpf
                 ref deviceParameters,
                 IntPtr.Zero,
                 out DXInterop.IDirect3DDevice9Ex dxDevice);
-
             DxDevice = dxDevice;
 
             // if the graphics context is null, we use the shared context.
-            if (settings.ContextToUse != null) {
+            if (settings.ContextToUse != null)
+            {
                 GraphicsContext = settings.ContextToUse;
             }
-            else {
+            else
+            {
                 NativeWindowSettings nws = NativeWindowSettings.Default;
                 nws.StartFocused = false;
                 nws.StartVisible = false;
@@ -101,6 +102,7 @@ namespace OpenTK.Wpf
                 GL.Enable(EnableCap.DebugOutputSynchronous);
 #endif
             }
+
 
             GLDeviceHandle = Wgl.DXOpenDeviceNV(dxDevice.Handle);
             if (GLDeviceHandle == IntPtr.Zero)

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -84,13 +84,13 @@ namespace OpenTK.Wpf
 
                 if (D3dImage != null)
                 {
-                    GL.DeleteFramebuffer(GLFramebufferHandle);
-                    GL.DeleteRenderbuffer(GLSharedDepthRenderRenderbufferHandle);
-                    GL.DeleteRenderbuffer(GLSharedColorRenderbufferHandle);
                     Wgl.DXUnregisterObjectNV(_context.GLDeviceHandle, DxInteropColorRenderTargetRegisteredHandle);
                     Wgl.DXUnregisterObjectNV(_context.GLDeviceHandle, DxInteropDepthStencilRenderTargetRegisteredHandle);
                     DxColorRenderTarget.Release();
                     DxDepthStencilRenderTarget.Release();
+                    GL.DeleteFramebuffer(GLFramebufferHandle);
+                    GL.DeleteRenderbuffer(GLSharedDepthRenderRenderbufferHandle);
+                    GL.DeleteRenderbuffer(GLSharedColorRenderbufferHandle);
                 }
                 D3dImage = null;
 

--- a/src/GLWpfControl/Interop/DXInterop.cs
+++ b/src/GLWpfControl/Interop/DXInterop.cs
@@ -1,13 +1,5 @@
-﻿using OpenTK.Graphics.OpenGL;
-using System;
-using System.Reflection.Metadata;
-using System.Runtime.CompilerServices;
-using System.Runtime.ConstrainedExecution;
+﻿using System;
 using System.Runtime.InteropServices;
-using System.Windows.Media.Media3D;
-using System.Windows.Media;
-using System.Windows;
-using System.Windows.Interop;
 
 namespace OpenTK.Wpf.Interop
 {
@@ -30,12 +22,14 @@ namespace OpenTK.Wpf.Interop
             static extern int Direct3DCreate9Ex(uint SdkVersion, out IDirect3D9Ex ctx);
         }
 
+        private delegate uint NativeGetAdapterCount(IDirect3D9Ex contextHandle);
+        private delegate int NativeCheckDeviceMultiSampleType(IDirect3D9Ex contextHandle, uint Adapter, DeviceType DeviceType, Format SurfaceFormat, bool Windowed, MultisampleType MultiSampleType, out uint pQualityLevels);
         private delegate int NativeCreateDeviceEx(IDirect3D9Ex contextHandle, int adapter, DeviceType deviceType, IntPtr focusWindowHandle, CreateFlags behaviorFlags, ref PresentationParameters presentationParameters, IntPtr fullscreenDisplayMode, out IDirect3DDevice9Ex deviceHandle);
         private delegate int NativeCreateRenderTarget(IDirect3DDevice9Ex deviceHandle, int width, int height, Format format, MultisampleType multisample, int multisampleQuality, bool lockable, out IDirect3DSurface9 surfaceHandle, ref IntPtr sharedHandle);
         private delegate int NativeCreateDepthStencilSurface(IDirect3DDevice9Ex deviceHandle, int width, int height, Format format, MultisampleType multisample, int multisampleQuality, bool discard, out IDirect3DSurface9 surfaceHandle, ref IntPtr sharedHandle);
         private delegate uint NativeRelease(IntPtr resourceHandle);
 
-        private delegate uint NativeGetDesc(IDirect3DSurface9 surfaceHandle, out D3DSURFACE_DESC pDesc);
+        private delegate uint NativeDirect3DSurface9_GetDesc(IDirect3DSurface9 surfaceHandle, out D3DSURFACE_DESC pDesc);
 
         public static void CheckHResult(int hresult)
         {
@@ -111,6 +105,22 @@ namespace OpenTK.Wpf.Interop
                 NativeRelease method = Marshal.GetDelegateForFunctionPointer<NativeRelease>((*VTable)->Release);
                 // FIXME: Figure out how we want to reference things
                 return method((IntPtr)VTable);
+            }
+
+            public int CheckDeviceMultiSampleType(uint Adapter, DeviceType DeviceType, Format SurfaceFormat, bool Windowed, MultisampleType MultiSampleType, out uint pQualityLevels)
+            {
+                NativeCheckDeviceMultiSampleType method = Marshal.GetDelegateForFunctionPointer<NativeCheckDeviceMultiSampleType>((*VTable)->CheckDeviceMultiSampleType);
+
+                int result = method(this, Adapter, DeviceType, SurfaceFormat, Windowed, MultiSampleType, out pQualityLevels);
+
+                return result;
+            }
+
+            public uint GetAdapterCount()
+            {
+                NativeGetAdapterCount method = Marshal.GetDelegateForFunctionPointer<NativeGetAdapterCount>((*VTable)->GetAdapterCount);
+
+                return method(this);
             }
 
             public void CreateDeviceEx(int adapter, DeviceType deviceType, IntPtr focusWindowHandle, CreateFlags behaviorFlags, ref PresentationParameters presentationParameters, IntPtr fullscreenDisplayMode, out IDirect3DDevice9Ex deviceHandle)
@@ -346,7 +356,7 @@ namespace OpenTK.Wpf.Interop
 
             public uint GetDesc(out D3DSURFACE_DESC pDesc)
             {
-                NativeGetDesc method = Marshal.GetDelegateForFunctionPointer<NativeGetDesc>((*VTable)->GetDesc);
+                NativeDirect3DSurface9_GetDesc method = Marshal.GetDelegateForFunctionPointer<NativeDirect3DSurface9_GetDesc>((*VTable)->GetDesc);
 
                 return method(this, out pDesc);
             }


### PR DESCRIPTION
Since `4.2.3` the control has been broken on some integrated graphics cards.
One of the key differences between the newer versions and `4.2.3` is the use of WDDM share handles.

This PR adds back the share handle use which seems to fix the issue on my AMD Radeon integrated graphics card.
But using any MSAA setting > 0 will result in a crash while my dedicated graphics card can handle MSAA fine.
I've not found any way to query if a specific MSAA version will work or not, maybe we just have to try and if the function fail we have to try again without MSAA...

Fixes #128 
Should fix #130