### PR TITLE
Fix DXGLContext dispose

### DIFF
--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -138,24 +138,25 @@ namespace OpenTK.Wpf
 
         public void Dispose()
         {
-            try
+            int error = 0;
+            if (GLDeviceHandle != IntPtr.Zero && Wgl.DXCloseDeviceNV(GLDeviceHandle) == false)
             {
-                if (GLDeviceHandle != IntPtr.Zero && Wgl.DXCloseDeviceNV(GLDeviceHandle) == false)
-                {
-                    throw new Win32Exception(DXInterop.GetLastError());
-                }
+                error = DXInterop.GetLastError();
             }
-            finally
+
+            GlfwWindow?.Dispose();
+            if (DxDevice.Handle != IntPtr.Zero)
             {
-                GlfwWindow?.Dispose();
-                if (DxDevice.Handle != IntPtr.Zero)
-                {
-                    DxDevice.Release();
-                }
-                if (DxContext.Handle != IntPtr.Zero)
-                {
-                    DxContext.Release();
-                }
+                DxDevice.Release();
+            }
+            if (DxContext.Handle != IntPtr.Zero)
+            {
+                DxContext.Release();
+            }
+
+            if (error != 0)
+            {
+                throw new Win32Exception(error);
             }
         }
 

--- a/src/GLWpfControl/DXGLContext.cs
+++ b/src/GLWpfControl/DXGLContext.cs
@@ -148,8 +148,14 @@ namespace OpenTK.Wpf
             finally
             {
                 GlfwWindow?.Dispose();
-                DxDevice.Release();
-                DxContext.Release();
+                if (DxDevice.Handle != IntPtr.Zero)
+                {
+                    DxDevice.Release();
+                }
+                if (DxContext.Handle != IntPtr.Zero)
+                {
+                    DxContext.Release();
+                }
             }
         }
 


### PR DESCRIPTION
This fixes a couple of things related to `DXGLContext` dispose:

- A call to `DXCloseDeviceNV` with an empty `GLDeviceHandle` crashes with AccessViolationException. This checks if `GLDeviceHandle` isn't empty beforehand.
- Removed finalizer dispose as it might run from any thread and `GlwfWindow` can only be disposed on main thread.
- Added a call to dispose before throwing an exception in ctor to ensure proper clean-up.

In my case I can now properly handle when the control can't initialize on integrated gpus without crashing. Maybe fixes [113](https://github.com/opentk/GLWpfControl/issues/113) and [132](https://github.com/opentk/GLWpfControl/issues/132) as they're similar to what I've encountered (though these may not be related as I now see that NativeWindow also has a finalizer).