### PR TITLE
Improve resource disposal of `GLWpfControl`

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -180,7 +180,9 @@ namespace OpenTK.Wpf
             // which causes the renderer to not reallocate the framebuffer
             // after the previous one has been deleted.
             // - Noggin_bops 2024-05-29
-            _renderer?.ReallocateFramebufferIfNeeded(0, 0, 1, 1, Format.X8R8G8B8, MultisampleType.D3DMULTISAMPLE_NONE);
+            if (_isStarted) {
+                _renderer?.ReallocateFramebufferIfNeeded(0, 0, 1, 1, Format.X8R8G8B8, MultisampleType.D3DMULTISAMPLE_NONE);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

 `GLWpfControl.OnUnloaded()` was updated to only release resorces if the control hasn't been disposed yet.


## Behavior

#### Before

`OnUnloaded` could be fired after the disposal of the control.

#### After

Resources are being released in `OnUnloaded` only when the control is active (`_isStarted` is true, which is basically from the moment it was started to the moment it's disposed).