### PR TITLE
Fixed crash in Unloaded after Dispose() call.

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -191,6 +191,8 @@ namespace OpenTK.Wpf
         public void Dispose()
         {
             _renderer?.Dispose();
+            // Unloaded can happen after Dispose() call. We must not access _renderer anymore.
+	    _renderer = null;
             _isStarted = false;
         }
 


### PR DESCRIPTION
Unloaded can happen after Dispose() call. We must not access _renderer there.