### PR TITLE
Fix MSAA crash in many cases.

### DIFF
--- a/src/GLWpfControl/GLWpfControl.cs
+++ b/src/GLWpfControl/GLWpfControl.cs
@@ -111,6 +111,12 @@ namespace OpenTK.Wpf
         [CLSCompliant(false)]
         public IGraphicsContext? Context => _renderer?.GLContext;
 
+        /// <summary>
+        /// If MSAA backbuffers can be created for this GLWpfControl.
+        /// If false any attempt to create an MSAA framebuffer will be ignored.
+        /// </summary>
+        public bool SupportsMSAA => _renderer?.SupportsMSAA ?? false;
+
         private TimeSpan? _lastRenderTime = TimeSpan.FromSeconds(-1);
 
         [Obsolete("This property has no effect. See RegisterToEventsDirectly.")]

--- a/src/GLWpfControl/GLWpfControlRenderer.cs
+++ b/src/GLWpfControl/GLWpfControlRenderer.cs
@@ -92,7 +92,20 @@ namespace OpenTK.Wpf
                 out DXInterop.IDirect3DSurface9 dxColorRenderTarget,
                 ref dxColorRenderTargetShareHandle);
 
+                IntPtr dxDepthStencilRenderTargetShareHandle = IntPtr.Zero;
+                _context.DxDevice.CreateDepthStencilSurface(
+                    FramebufferWidth,
+                    FramebufferHeight,
+                    Format.D24S8,
+                    MultisampleType.D3DMULTISAMPLE_2_SAMPLES,
+                    0,
+                    false,
+                    out DXInterop.IDirect3DSurface9 dxDepthStencilRenderTarget,
+                    ref dxDepthStencilRenderTargetShareHandle);
+                DxDepthStencilRenderTarget = dxDepthStencilRenderTarget;
+
                 dxColorRenderTarget.Release();
+                dxDepthStencilRenderTarget.Release();
 
                 return true;
             }


### PR DESCRIPTION
This PR adds a quick and dirty check for trying to create an MSAA framebuffer and if that fails we don't try to create MSAA framebuffers even if the user requests MSAA. This fixes MSAA crashes on many computers.

Partially fixes #140, #138, and #134
It probably doesn't fix the integrated graphics issue.